### PR TITLE
Back.identification

### DIFF
--- a/Back/.envDefault
+++ b/Back/.envDefault
@@ -1,4 +1,6 @@
 NODE_ENV=development
 PORT=3000
+# Set your JTW secret key information here
+JWTSECRETKEY=
 # Set your database connection information here
 MONGO_KEY=

--- a/Back/.envDefault
+++ b/Back/.envDefault
@@ -1,5 +1,7 @@
 NODE_ENV=development
 PORT=3000
+# Set your JTW token for test information here
+TOKEN_TEST=
 # Set your JTW secret key information here
 JWTSECRETKEY=
 # Set your database connection information here

--- a/Back/app.js
+++ b/Back/app.js
@@ -21,20 +21,17 @@ app.use('/', indexRouter);
 app.use('/users', usersRouter);
 app.use('/points', pointsRouter);
 
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  next(createError(404));
-});
-
 // error handler
+// TODO Log system into files one for errors, for auth, login ...
 app.use(function(err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
+  res.locals.error = process.env.NODE_ENV === 'development' ? err : {};
 
   // render the error page
   console.log(err);
   res.status(err.status || 500);
+  res.send(err);
   res.end();
 });
 

--- a/Back/factories/usersFactory.js
+++ b/Back/factories/usersFactory.js
@@ -1,0 +1,23 @@
+var User = require('../models/userModel');
+const jwt = require('jsonwebtoken');
+
+var createNewUser = async (userData) => {
+    var user = new User(userData);
+    try {
+        const token = await newAuthToken(user);
+        return { user, token };
+    } catch (e) {
+        throw e;
+    }
+}
+
+var newAuthToken = async (user) => {
+    const token = jwt.sign({ _id: user.id.toString() }, process.env.JWTSECRETKEY, { expiresIn: "7 days" });
+    user.tokens = user.tokens.concat({ token })
+    await user.save()
+    return token
+}
+
+module.exports = {
+    createNewUser
+};

--- a/Back/factories/usersFactory.js
+++ b/Back/factories/usersFactory.js
@@ -3,8 +3,8 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 
 var createNewUser = async (userData) => {
-    var user = new User(userData);
     try {
+        var user = new User(userData);
         return await newAuthToken(user);
     } catch (e) {
         throw e;

--- a/Back/factories/usersFactory.js
+++ b/Back/factories/usersFactory.js
@@ -32,8 +32,8 @@ var login = async (user) => {
             throw new Error('401 : NotConnected');
         }
 
-        userFound = addNewToken(userFound);
-        return userFound;
+        userFound = await addNewToken(userFound);
+        return userFound.tokens.slice(-1)[0];
     } catch (error) {
         throw error;
     }

--- a/Back/factories/usersFactory.js
+++ b/Back/factories/usersFactory.js
@@ -1,11 +1,12 @@
 var User = require('../models/userModel');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 
 var createNewUser = async (userData) => {
     var user = new User(userData);
     try {
         const token = await newAuthToken(user);
-        return { user, token };
+        return token;
     } catch (e) {
         throw e;
     }
@@ -13,9 +14,14 @@ var createNewUser = async (userData) => {
 
 var newAuthToken = async (user) => {
     const token = jwt.sign({ _id: user.id.toString() }, process.env.JWTSECRETKEY, { expiresIn: "7 days" });
-    user.tokens = user.tokens.concat({ token })
-    await user.save()
-    return token
+    try {
+        user.password = await bcrypt.hash(user.password, 10);
+        user.tokens = user.tokens.concat({ token })
+        await user.save();
+    } catch (error) {
+        throw error;
+    }
+    return token;
 }
 
 module.exports = {

--- a/Back/factories/usersFactory.js
+++ b/Back/factories/usersFactory.js
@@ -41,7 +41,7 @@ var login = async (user) => {
 
 /// TODO Tokens expiration date verification
 var addNewToken = async (user) => {
-    const token = jwt.sign({ _id: user.id.toString() }, process.env.JWTSECRETKEY, { expiresIn: "7 days" });
+    const token = jwt.sign({ _id: user._id.toString() }, process.env.JWTSECRETKEY, { expiresIn: "7 days" });
     user.tokens = user.tokens.concat({token});
     try {
         await user.save();

--- a/Back/middlewares/authentification.js
+++ b/Back/middlewares/authentification.js
@@ -1,0 +1,22 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/userModel');
+
+const authentification = async (req,res,next) => {
+    try {
+        const token = req.header('Authorization').replace('Bearer', '').trim();
+        const decoded = jwt.verify(token, process.env.JWTSECRETKEY);
+        const user = await User.findOne({ _id: decoded._id, 'tokens.token': token });
+
+        if(!user){
+            throw new Error();
+        }
+        req.token = token;
+        req.user = user;
+        next()
+    } catch (error) {
+        console.log(error);
+        res.status(401).send({ error: 'Please authenticate!' });
+    }
+}
+
+module.exports = authentification;

--- a/Back/middlewares/authentification.js
+++ b/Back/middlewares/authentification.js
@@ -2,21 +2,24 @@ const jwt = require('jsonwebtoken');
 const User = require('../models/userModel');
 
 const authentification = async (req,res,next) => {
-    try {
-        const token = req.header('Authorization').replace('Bearer', '').trim();
-        const decoded = jwt.verify(token, process.env.JWTSECRETKEY);
-        const user = await User.findOne({ _id: decoded._id, 'tokens.token': token });
+    var authorization = req.header('Authorization');
+    if(authorization) {
+        try {
+            const token = authorization.replace('Bearer', '').trim();
+            const decoded = jwt.verify(token, process.env.JWTSECRETKEY);
+            const user = await User.findOne({ _id: decoded._id, 'tokens.token': token });
 
-        if(!user){
-            throw new Error();
+            if(!user){
+                throw new Error();
+            }
+            req.token = token;
+            req.user = user;
+        } catch (error) {
+            console.log(error);
+            res.status(401).send({ error: 'Please authenticate!' });
         }
-        req.token = token;
-        req.user = user;
-        next()
-    } catch (error) {
-        console.log(error);
-        res.status(401).send({ error: 'Please authenticate!' });
     }
+    next();
 }
 
 module.exports = authentification;

--- a/Back/middlewares/authentification.js
+++ b/Back/middlewares/authentification.js
@@ -12,8 +12,8 @@ const authentification = async (req,res,next) => {
             if(!user){
                 throw new Error();
             }
-            req.token = token;
-            req.user = user;
+
+            res.send({token}).end();
         } catch (error) {
             console.log(error);
             res.status(401).send({ error: 'Please authenticate!' });

--- a/Back/models/userModel.js
+++ b/Back/models/userModel.js
@@ -1,0 +1,46 @@
+const db = require('../factories/databaseFactory');
+const validator = require('validator');
+
+var schema = {
+    name:{
+        type: String,
+        required: true,
+        trim: true
+    },
+    email:{
+        type: String,
+        required: true,
+        unique:true,
+        trim: true,
+        validate(value){
+            if(!validator.isEmail(value)){
+                throw new Error('Email is invalid!')
+            }
+        }
+    },
+    password:{
+        type:String,
+        required:true,
+        trim:true,
+        minlength: 7,
+        validate(value){
+            if(validator.isEmpty(value)){
+                throw new Error('Please enter your password!')
+            }
+        }
+    },
+    tokens:[{
+        token:{
+            type:String,
+            required: true
+        }
+    }],
+    createdAt:{
+        type: Date,
+        default: Date.now
+    }
+};
+
+var userModel = new db.Schema(schema);
+
+module.exports = db.mongoose.model('User', userModel, 'Users');

--- a/Back/models/userModel.js
+++ b/Back/models/userModel.js
@@ -5,6 +5,7 @@ var schema = {
     name:{
         type: String,
         required: true,
+        unique:true,
         trim: true
     },
     email:{

--- a/Back/package.json
+++ b/Back/package.json
@@ -19,6 +19,7 @@
     "mongodb": "^3.4.0",
     "mongoose": "^5.8.1",
     "morgan": "~1.9.1",
+    "supertest": "^4.0.2",
     "validator": "^12.2.0"
   }
 }

--- a/Back/package.json
+++ b/Back/package.json
@@ -7,15 +7,18 @@
     "test": "mocha --timeout 60000 --exit"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
     "geojson": "^0.5.0",
     "http-errors": "~1.6.3",
+    "jsonwebtoken": "^8.5.1",
     "mocha": "^7.0.0",
     "mongodb": "^3.4.0",
     "mongoose": "^5.8.1",
-    "morgan": "~1.9.1"
+    "morgan": "~1.9.1",
+    "validator": "^12.2.0"
   }
 }

--- a/Back/routes/users.js
+++ b/Back/routes/users.js
@@ -9,9 +9,13 @@ router.get('/', function(req, res, next) {
   res.end();
 });
 
-router.post('/register', function (req, res, next) {
-  usersFactory.createNewUser(req.body);
-  res.end();
+router.post('/register', async function (req, res, next) {
+  try {
+    var token = await usersFactory.createNewUser(req.body);
+    res.status(200).send({token}).end();
+  } catch (error) {
+    next(error);
+  }
 });
 
 router.post('/login', authentification, function (req, res, next) {

--- a/Back/routes/users.js
+++ b/Back/routes/users.js
@@ -19,8 +19,8 @@ router.post('/register', async function (req, res, next) {
 
 router.post('/login', authentification, async function (req, res, next) {
   try {
-    var user = await usersFactory.login(req.body);
-    res.status(200).end()
+    var token = req.token || await usersFactory.login(req.body);
+    res.status(200).send(token).end();
   } catch (error) {
     next(error)  ;
   }

--- a/Back/routes/users.js
+++ b/Back/routes/users.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const authentification = require('../middlewares/authentification');
-const {ObjectID}  = require('mongodb')
 var usersFactory = require('../factories/usersFactory');
 
 /* GET users listing. */
@@ -18,9 +17,13 @@ router.post('/register', async function (req, res, next) {
   }
 });
 
-router.post('/login', authentification, function (req, res, next) {
-  //usersFactory.make
-  res.end();
+router.post('/login', authentification, async function (req, res, next) {
+  try {
+    var user = await usersFactory.login(req.body);
+    res.status(200).end()
+  } catch (error) {
+    next(error)  ;
+  }
 });
 
 module.exports = router;

--- a/Back/routes/users.js
+++ b/Back/routes/users.js
@@ -1,8 +1,21 @@
-var express = require('express');
-var router = express.Router();
+const express = require('express');
+const router = express.Router();
+const authentification = require('../middlewares/authentification');
+const {ObjectID}  = require('mongodb')
+var usersFactory = require('../factories/usersFactory');
 
 /* GET users listing. */
 router.get('/', function(req, res, next) {
+  res.end();
+});
+
+router.post('/register', function (req, res, next) {
+  usersFactory.createNewUser(req.body);
+  res.end();
+});
+
+router.post('/login', authentification, function (req, res, next) {
+  //usersFactory.make
   res.end();
 });
 

--- a/Back/test/usersRouteTest.js
+++ b/Back/test/usersRouteTest.js
@@ -1,0 +1,101 @@
+var assert = require('assert');
+var request = require('supertest');
+var User = require('../models/userModel');
+var app = require('../app');
+var agent = request.agent(app);
+
+const dummyName = "Dummy Foo";
+const dummyEmail = "Dummy.Foo@asylum.io";
+const dummyPassword = "MyP4ZZVV0RDEZ";
+const totoEmail = "totoCfollegue@toto.fr";
+const totoPassword = "totoestlemotdepasse";
+
+
+describe('/user tests', () => {
+    describe('#POST /login without token', () => {
+        var response;
+        before((done) => {
+            agent.post('/users/login')
+                .send({
+                    "email": totoEmail,
+                    "password": totoPassword
+                })
+                .end((err, res) => {
+                    if(err) { done(err);}
+                    else {
+                        response = res;
+                        done();
+                    }
+                });
+        });
+
+        it('Expect response have status 200', (done) => {
+            assert.ok(response.status == 200);
+            done();
+        });
+
+        it('Expect response have token', (done) => {
+            assert.ok(response.body.token);
+            done();
+        });
+    });
+
+    describe('#POST /login with token', () => {
+        var response;
+        before((done) => {
+            agent.post('/users/login')
+                .set('Token', process.env.TOKEN_TEST)
+                .send({
+                    'email': totoEmail,
+                    'password': totoPassword
+                })
+                .end((err, res) => {
+                    if(err) { done(err);}
+                    else {
+                        response = res;
+                        done();
+                    }
+                });
+        });
+
+        it('Expect response have status 200', (done) => {
+            assert.ok(response.status == 200);
+            done();
+        });
+    });
+
+    describe('#POST /register no errors', () => {
+        var response;
+        before((done) => {
+            agent.post('/users/register')
+                .send({
+                    "name": dummyName,
+                    "password": dummyPassword,
+                    "email": dummyEmail
+                })
+                .end((err, res) => {
+                    if(err) { done(err);}
+                    else {
+                        response = res;
+                        done();
+                    }
+                });
+        });
+
+        it('Expect response have status 200', (done) => {
+            assert.ok(response.status == 200);
+            done();
+        });
+
+        it('Expect response have tokens', (done) => {
+            assert.ok(response.body.token);
+            done();
+        });
+
+        after((done) => {
+            User.deleteOne({name: dummyName, email: dummyEmail}, (err) => {
+                done(err);
+            });
+        })
+    });
+});


### PR DESCRIPTION
Ajout de l'identification et la création de compte niveau Back.
Schéma des routes de l'API pour ces fonctionnalités :

- POST /users/register : création de compte; 
Les paramètres attendus dans le body de la requête en provenance du Front sont :
`{
   email: <email>,
   name: <name>,
   password: <password>
}`
La réponse en cas de succès sera un token à conserver sur le téléphone pour une authentification ultérieure.

- POST /users/login : connexion avec ou sans token 
   - Sans Token : 
   Renseignez dans le body de requête les paramètres suivants : 
`{
   email: <email>,
   password: <password>
}`

   - Avec Token : 
   Renseignez le dans le Header de votre requête comme suit : `'Authorization' : '<token>' `.
   Dans ce cas les paramètres précédents seront ignorés.


Vous trouverez aussi les tests associés pour ces nouvelles routes.
Pour simuler les requêtes posts, j'ai utilisé le package `supertests` donc n'oubliez pas le `npm install` !
J'ai ajouté aussi deux nouvelles variables d'environnement, je vous les donnes au besoin !
Pour les tests sur travis, ne vous inquiétiez pas, elles sont déjà renseignées pour toutes les branches 

Et comme d'habitudes, n'hésitez pas sur les remarques :) 
